### PR TITLE
Allow inserting fuel into Distil from the sides

### DIFF
--- a/src/main/java/train/common/core/handlers/ConfigHandler.java
+++ b/src/main/java/train/common/core/handlers/ConfigHandler.java
@@ -32,7 +32,7 @@ public class ConfigHandler {
 	public static int TRAINCRAFT_VILLAGER_ID;
 	public static boolean REAL_TRAIN_SPEED;
 	public static boolean RETROGEN_CHUNKS;
-	public static boolean	MAKE_MODPACKS_BETTER;
+	public static boolean	MAKE_MODPACKS_GREAT_AGAIN;
 
 
 
@@ -59,7 +59,7 @@ public class ConfigHandler {
 			SHOW_POSSIBLE_COLORS = SHOW_POSSIBLE_COLORS_PROP.getBoolean(true);
 			REAL_TRAIN_SPEED = cf.get(CATEGORY_GENERAL, "REAL_TRAIN_SPEED", false).getBoolean(false);
 			RETROGEN_CHUNKS = cf.getBoolean("ENABLE_RETROGEN", CATEGORY_GENERAL, false, "This will generate ores in existing chunks prior to installing Traincraft 5. Do note that if this is off chunks that are loaded will not retrogen later, no matter what.");
-			MAKE_MODPACKS_BETTER = cf.getBoolean("BETTER_MODPACKS", CATEGORY_GENERAL, false,
+			MAKE_MODPACKS_GREAT_AGAIN = cf.getBoolean("MAKE_MODPACKS_GREAT_AGAIN", CATEGORY_GENERAL, false,
 					"This will disable some of Traincrafts easier recipes to balance Modpacks");
 
 

--- a/src/main/java/train/common/core/handlers/RecipeHandler.java
+++ b/src/main/java/train/common/core/handlers/RecipeHandler.java
@@ -148,7 +148,7 @@ public class RecipeHandler {
 		TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.ironFirebox.item, 2), new Object[] { "###", "#X#", "###", Character.valueOf('#'), Items.iron_ingot, Character.valueOf('X'), Items.flint_and_steel });// iron Firebox  
 		TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.ironChimney.item, 2), new Object[] { "# #", "# #", "# #", Character.valueOf('#'), Items.iron_ingot });
 		
-		if (ConfigHandler.MAKE_MODPACKS_BETTER) {
+		if (ConfigHandler.MAKE_MODPACKS_GREAT_AGAIN) {
 			TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.coaldust.item, 4),
 					new Object[] { "###", "   ", "   ", Character.valueOf('#'), Items.coal });
 			TrainCraftingManager.instance.addRecipe(new ItemStack(ItemIDs.coaldust.item, 4),

--- a/src/main/java/train/common/tile/TileEntityDistil.java
+++ b/src/main/java/train/common/tile/TileEntityDistil.java
@@ -376,7 +376,9 @@ public class TileEntityDistil extends TileTraincraft implements IFluidHandler {
 
 	@Override
 	public boolean canInsertItem(int slot, ItemStack stack, int side){
-		return side != 0 && slot == 0;
+		if(side == 0) return false;          // bottom is extract only
+		else if(side == 1) return slot == 0; // insert input into top
+		else return slot == 1;               // insert fuel into sides
 	}
 
 	@Override


### PR DESCRIPTION
This matches vanilla Furnaces, which allow inputs in the top and fuel
items from the sides.