### PR TITLE
Add Inventory Tweaks support for InventoryFreight

### DIFF
--- a/src/main/java/invtweaks/api/IItemTree.java
+++ b/src/main/java/invtweaks/api/IItemTree.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2013 Andrew Crocker
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package invtweaks.api;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Random;
+
+public interface IItemTree {
+    public void registerOre(String category, String name, String oreName, int order);
+
+    boolean matches(List<IItemTreeItem> items, String keyword);
+
+    boolean isKeywordValid(String keyword);
+
+    Collection<IItemTreeCategory> getAllCategories();
+
+    IItemTreeCategory getRootCategory();
+
+    void setRootCategory(IItemTreeCategory category);
+
+    IItemTreeCategory getCategory(String keyword);
+
+    boolean isItemUnknown(String id, int damage);
+
+    List<IItemTreeItem> getItems(String id, int damage);
+
+    List<IItemTreeItem> getItems(String name);
+
+    IItemTreeItem getRandomItem(Random r);
+
+    boolean containsItem(String name);
+
+    boolean containsCategory(String name);
+
+    IItemTreeCategory addCategory(String parentCategory, String newCategory) throws NullPointerException;
+
+    void addCategory(String parentCategory, IItemTreeCategory newCategory) throws NullPointerException;
+
+    IItemTreeItem addItem(String parentCategory, String name, String id, int damage, int order)
+            throws NullPointerException;
+
+    void addItem(String parentCategory, IItemTreeItem newItem) throws NullPointerException;
+
+    int getKeywordDepth(String keyword);
+
+    int getKeywordOrder(String keyword);
+}

--- a/src/main/java/invtweaks/api/IItemTreeCategory.java
+++ b/src/main/java/invtweaks/api/IItemTreeCategory.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2013 Andrew Crocker
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package invtweaks.api;
+
+import java.util.Collection;
+import java.util.List;
+
+public interface IItemTreeCategory {
+    boolean contains(IItemTreeItem item);
+
+    void addCategory(IItemTreeCategory category);
+
+    void addItem(IItemTreeItem item);
+
+    Collection<IItemTreeCategory> getSubCategories();
+
+    Collection<List<IItemTreeItem>> getItems();
+
+    String getName();
+
+    int getCategoryOrder();
+
+    int findCategoryOrder(String keyword);
+
+    int findKeywordDepth(String keyword);
+}

--- a/src/main/java/invtweaks/api/IItemTreeItem.java
+++ b/src/main/java/invtweaks/api/IItemTreeItem.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2013 Andrew Crocker
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package invtweaks.api;
+
+public interface IItemTreeItem extends Comparable<IItemTreeItem> {
+    String getName();
+
+    String getId();
+
+    int getDamage();
+
+    int getOrder();
+}

--- a/src/main/java/invtweaks/api/IItemTreeListener.java
+++ b/src/main/java/invtweaks/api/IItemTreeListener.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2013 Andrew Crocker
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package invtweaks.api;
+
+import java.util.EventListener;
+
+public interface IItemTreeListener extends EventListener {
+    void onTreeLoaded(IItemTree tree);
+}

--- a/src/main/java/invtweaks/api/InvTweaksAPI.java
+++ b/src/main/java/invtweaks/api/InvTweaksAPI.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2013 Andrew Crocker
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package invtweaks.api;
+
+import invtweaks.api.container.ContainerSection;
+import net.minecraft.item.ItemStack;
+
+/**
+ * Interface to access functions exposed by Inventory Tweaks
+ * <p/>
+ * The main @Mod instance of the mod implements this interface, so a refernce to it can
+ * be obtained via @Instance("inventorytweaks") or methods in net.minecraftforge.fml.common.Loader
+ * <p/>
+ * All of these functions currently have no effect if called on a dedicated server.
+ */
+public interface InvTweaksAPI {
+    /**
+     * Add a listener for ItemTree load events
+     *
+     * @param listener
+     */
+    void addOnLoadListener(IItemTreeListener listener);
+
+    /**
+     * Remove a listener for ItemTree load events
+     *
+     * @param listener
+     * @return true if the listener was previously added
+     */
+    boolean removeOnLoadListener(IItemTreeListener listener);
+
+    /**
+     * Toggle sorting shortcut state.
+     *
+     * @param enabled
+     */
+    void setSortKeyEnabled(boolean enabled);
+
+    /**
+     * Toggle sorting shortcut supression.
+     * Unlike setSortKeyEnabled, this flag is automatically cleared when GUIs are closed.
+     *
+     * @param enabled
+     */
+    void setTextboxMode(boolean enabled);
+
+    /**
+     * Compare two items using the default (non-rule based) algorithm,
+     * sutable for an implementation of Comparator&lt;ItemStack&gt;.
+     *
+     * @param i
+     * @param j
+     * @return A value with a sign representing the relative order of the item stacks
+     */
+    int compareItems(ItemStack i, ItemStack j);
+
+    /**
+     * Initiate a sort as if the player had clicked on a sorting button or pressed the sort key.
+     *
+     * @param section
+     * @param method
+     */
+    void sort(ContainerSection section, SortingMethod method);
+}

--- a/src/main/java/invtweaks/api/SortingMethod.java
+++ b/src/main/java/invtweaks/api/SortingMethod.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2013 Andrew Crocker
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package invtweaks.api;
+
+public enum SortingMethod {
+    /**
+     * Standard 'r' sorting for generic inventories
+     */
+    DEFAULT,
+    /**
+     * Sort method creating vertical columns of items.
+     * Used for chests only, requires container to have a valid row size for correct results.
+     */
+    VERTICAL,
+    /**
+     * Sort method creating horizontal rows of items.
+     * Used for chests only, requires container to have a valid row size for correct results.
+     */
+    HORIZONTAL,
+    /**
+     * Sort method for player inventory.
+     * Applies to extra player-specified sorting rules for the main inventory.
+     * Will always operate on main inventory.
+     */
+    INVENTORY,
+    /**
+     * Attempts to even the number of items in each stack of the same type of item, without moving full stacks.
+     * Used in crafting grid sorting.
+     */
+    EVEN_STACKS,
+}

--- a/src/main/java/invtweaks/api/container/ChestContainer.java
+++ b/src/main/java/invtweaks/api/container/ChestContainer.java
@@ -1,0 +1,38 @@
+package invtweaks.api.container;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * A marker for containers that have a chest-like persistant storage component. Enables the Inventroy Tweaks sorting
+ * buttons for this container.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface ChestContainer {
+    // Set to true if the Inventory Tweaks sorting buttons should be shown for this container.
+    boolean showButtons() default true;
+
+    // Size of a chest row
+    int rowSize() default 9;
+
+    // Uses 'large chest' mode for sorting buttons
+    // (Renders buttons vertically down the right side of the GUI)
+    boolean isLargeChest() default false;
+
+    // Annotation for method to get size of a chest row if it is not a fixed size for this container class
+    // Signature int func()
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.METHOD)
+    public @interface RowSizeCallback {
+    }
+
+    // Annotation for method to get size of a chest row if it is not a fixed size for this container class
+    // Signature int func()
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.METHOD)
+    public @interface IsLargeCallback {
+    }
+}

--- a/src/main/java/invtweaks/api/container/ContainerSection.java
+++ b/src/main/java/invtweaks/api/container/ContainerSection.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2013 Andrew Crocker
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package invtweaks.api.container;
+
+/**
+ * Names for specific parts of containers. For unknown container types (such as mod containers), only INVENTORY and
+ * CHEST sections are available.
+ */
+public enum ContainerSection {
+    /**
+     * The player's inventory
+     */
+    INVENTORY,
+    /**
+     * The player's inventory (only the hotbar)
+     */
+    INVENTORY_HOTBAR,
+    /**
+     * The player's inventory (all except the hotbar)
+     */
+    INVENTORY_NOT_HOTBAR,
+    /**
+     * The chest or dispenser contents. Also used for unknown container contents.
+     */
+    CHEST,
+    /**
+     * The crafting input
+     */
+    CRAFTING_IN,
+    /**
+     * The crafting input, for containters that store it internally
+     */
+    CRAFTING_IN_PERSISTENT,
+    /**
+     * The crafting output
+     */
+    CRAFTING_OUT,
+    /**
+     * The armor slots
+     */
+    ARMOR,
+    /**
+     * The furnace input
+     */
+    FURNACE_IN,
+    /**
+     * The furnace output
+     */
+    FURNACE_OUT,
+    /**
+     * The furnace fuel
+     */
+    FURNACE_FUEL,
+    /**
+     * The enchantment table slot
+     */
+    ENCHANTMENT,
+    /**
+     * The three bottles slots in brewing tables
+     * NOTE: Do not use without also using BREWING_INGREDIENT.
+     */
+    BREWING_BOTTLES,
+    /**
+     * The top slot in brewing tables
+     * NOTE: Do not use without also using BREWING_BOTTLES.
+     */
+    BREWING_INGREDIENT
+}

--- a/src/main/java/invtweaks/api/container/ContainerSectionCallback.java
+++ b/src/main/java/invtweaks/api/container/ContainerSectionCallback.java
@@ -1,0 +1,16 @@
+package invtweaks.api.container;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * A marker for a method to call which returns the set of ContainerSections for this container.
+ * <p/>
+ * Signature of the method should be Map<ContainerSection, List<Slot>> func()
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface ContainerSectionCallback {
+}

--- a/src/main/java/invtweaks/api/container/IgnoreContainer.java
+++ b/src/main/java/invtweaks/api/container/IgnoreContainer.java
@@ -1,0 +1,15 @@
+package invtweaks.api.container;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Use this annotation to override inherited annotation properties and mark a Container as unsortable.
+ * This effect is inherited as well.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface IgnoreContainer {
+}

--- a/src/main/java/invtweaks/api/container/InventoryContainer.java
+++ b/src/main/java/invtweaks/api/container/InventoryContainer.java
@@ -1,0 +1,20 @@
+package invtweaks.api.container;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * A marker for containers that need special treatment, such as crafting inputs or alternate player inventory positions,
+ * but do not have a chest-like component.
+ * <p/>
+ * Does not enable the Inventory Tweaks sorting buttons for this container.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface InventoryContainer {
+    // Set to true if the Inventory Tweaks options button should be shown for this container.
+    // (For instance, if you are replacing a vanilla container such as the player's inventory)
+    boolean showOptions() default true;
+}

--- a/src/main/java/train/common/inventory/InventoryFreight.java
+++ b/src/main/java/train/common/inventory/InventoryFreight.java
@@ -1,5 +1,9 @@
 package train.common.inventory;
 
+import cpw.mods.fml.common.Optional;
+import invtweaks.api.container.ChestContainer;
+import invtweaks.api.container.ContainerSection;
+import invtweaks.api.container.ContainerSectionCallback;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.Container;
 import net.minecraft.inventory.IInventory;
@@ -8,6 +12,11 @@ import net.minecraft.item.ItemStack;
 import train.common.api.Freight;
 import train.common.slots.SlotFreight;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@ChestContainer()
 public class InventoryFreight extends Container {
 
 	private Freight freight;
@@ -159,5 +168,20 @@ public class InventoryFreight extends Container {
 			}
 		}
 		return var5;
+	}
+
+	// Inventory Tweaks Compat
+	@ContainerSectionCallback
+	@Optional.Method(modid = "inventorytweaks")
+	public Map<ContainerSection, List<Slot>> getContainerSections() {
+		Map<ContainerSection, List<Slot>> sectSlots = new HashMap<ContainerSection, List<Slot>>();
+
+		int freightSlots = height * 9;
+		sectSlots.put(ContainerSection.CHEST, inventorySlots.subList(0, freightSlots));
+		sectSlots.put(ContainerSection.INVENTORY, inventorySlots.subList(freightSlots, freightSlots + 36));
+		sectSlots.put(ContainerSection.INVENTORY_NOT_HOTBAR, inventorySlots.subList(freightSlots, freightSlots + 27));
+		sectSlots.put(ContainerSection.INVENTORY_HOTBAR, inventorySlots.subList(freightSlots + 27, freightSlots + 36));
+
+		return sectSlots;
 	}
 }


### PR DESCRIPTION
Only adds support for InventoryFreight any nothing else.

Was going to add the Inventory Tweaks API into the api sub-project, but because existing apis were added to the main sub-project, decided to follow existing convention.

Should this PR include support for other inventories too?